### PR TITLE
Remove LANG declaration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,4 @@ RUN curl -O $host/$rpm \
     && yum install -y fontconfig \
     && yum clean all
 
-ENV LANG C.utf8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/test-image.yaml
+++ b/test-image.yaml
@@ -4,8 +4,6 @@ metadataTest:
   env:
     - key: JAVA_HOME
       value: /usr/lib/jvm/java-11-amazon-corretto
-    - key: LANG
-      value: C.utf8
 
 commandTests:
   - name: "java command is registered using alternatives."


### PR DESCRIPTION
AL2's fontconfig currently doesn't recognize "C.utf8". While
that's being worked on, we'll allow users to pick their LANG.

Fixes #4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
