### PR TITLE
Update Dockerfile for 11 GA.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM amazonlinux:2
 
-ARG rpm=java-11-amazon-corretto-devel-11.0.2.9-2.x86_64.rpm
-ARG host=https://d2jnoze5tfhthg.cloudfront.net
-ARG key=CEA07BEBCDC52045018DD4A35928EBD97E2223C5
+ARG rpm=java-11-amazon-corretto-devel-11.0.2.9-3.x86_64.rpm
+ARG path=https://d3pxv6yz143wms.cloudfront.net/11.0.2.9.3
+ARG key=1BD3F7FB61E53C4F0F0B1C1E9471DD1D11E0D862
 
 # In addition to installing the RPM, we also install
 # fontconfig. The folks who manage the docker hub's
@@ -14,7 +14,7 @@ ARG key=CEA07BEBCDC52045018DD4A35928EBD97E2223C5
 #  https://github.com/docker-library/official-images/blob/master/test/tests/java-uimanager-font/container.java
 
 
-RUN curl -O $host/$rpm \
+RUN curl -O $path/$rpm \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys $key \
     && gpg --armor --export $key > corretto.asc \


### PR DESCRIPTION
Updates the Dockerfile to use the GA version of Corretto 11: https://aws.amazon.com/about-aws/whats-new/2019/03/amazon-corretto-11-is-now-generally-available/