### PR TITLE
Add Corretto 11 docker for aarch64 platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM amazonlinux:2
 
-ARG rpm=java-11-amazon-corretto-devel-11.0.4.11-1.x86_64.rpm
-ARG path=https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1
-ARG key=4FF3DA639731F095833505A25A812B5B67F4FCB4
+# x86_64 args
+ARG rpm_x64=java-11-amazon-corretto-devel-11.0.4.11-1.x86_64.rpm
+ARG path_x64=https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1
+ARG key_x64=4FF3DA639731F095833505A25A812B5B67F4FCB4
+
+# aarch64 args
+ARG rpm_aarch64=java-11-amazon-corretto-devel-11.0.4.11-1.aarch64.rpm
+ARG path_aarch64=https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1
+ARG key_aarch64=4FF3DA639731F095833505A25A812B5B67F4FCB4
 
 # In addition to installing the RPM, we also install
 # fontconfig. The folks who manage the docker hub's
@@ -12,9 +18,14 @@ ARG key=4FF3DA639731F095833505A25A812B5B67F4FCB4
 #
 # See:
 #  https://github.com/docker-library/official-images/blob/master/test/tests/java-uimanager-font/container.java
-
-
-RUN curl -O $path/$rpm \
+RUN set -eux; \
+    case "$(uname -p)" in \
+        x86_64) rpm=$rpm_x64; path=$path_x64; key=$key_x64 ;; \
+        aarch64) rpm=$rpm_aarch64; path=$path_aarch64; key=$key_aarch64 ;; \
+        *) echo >&2 "Unsupported architecture $(uname -p)."; exit 1 ;; \
+    esac; \
+    \
+    curl -O $path/$rpm \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys $key \
     && gpg --armor --export $key > corretto.asc \


### PR DESCRIPTION
Enable the docker build based on Amazon linux 2 aarch64 image.

As Corretto aarch64 Linux build reaches [release-candidate stage](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/change-log.html#changes-2019-07-16), we need to support AL2-based Corretto 11 image on aarch64 platform.

### Tests performed:
* On x64 Amazon Linux 2 EC2:
```
[ec2-user@ip-10-0-0-171 ~]$ docker build -t corretto-11-docker:test .
...
+ rpm=java-11-amazon-corretto-devel-11.0.4.11-1.x86_64.rpm
+ path=https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1
+ key=4FF3DA639731F095833505A25A812B5B67F4FCB4
+ curl -O https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/java-11-amazon-corretto-devel-11.0.4.11-1.x86_64.rpm
...
[ec2-user@ip-10-0-0-171 ~]$ docker run --rm corretto-11-docker:test java -version
openjdk version "11.0.4" 2019-07-16 LTS
OpenJDK Runtime Environment Corretto-11.0.4.11.1 (build 11.0.4+11-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.4.11.1 (build 11.0.4+11-LTS, mixed mode)
```

* On aarch64 Amazon Linux 2 EC2:
```
[ec2-user@ip-10-0-0-171 ~]$ docker build -t corretto-11-docker:test .
...
+ rpm=java-11-amazon-corretto-devel-11.0.4.11-1.aarch64.rpm
+ path=https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1
+ key=4FF3DA639731F095833505A25A812B5B67F4FCB4
+ curl -O https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/java-11-amazon-corretto-devel-11.0.4.11-1.aarch64.rpm
...
[ec2-user@ip-10-0-0-171 ~]$ docker run --rm corretto-11-docker:test java -version
openjdk version "11.0.4" 2019-07-16 LTS
OpenJDK Runtime Environment Corretto-11.0.4.11.1 (build 11.0.4+11-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.4.11.1 (build 11.0.4+11-LTS, mixed mode)
```