### PR TITLE
switch default locale to utf8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ RUN set -eux \
     && yum install -y fontconfig \
     && yum clean all
 
+ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/contrib/debian/Dockerfile
+++ b/contrib/debian/Dockerfile
@@ -51,4 +51,6 @@ RUN set -eux; \
 	rm -rf $GNUPGHOME corretto.asc $deb; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false curl dirmngr gnupg
 
+ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/test-image.yaml
+++ b/test-image.yaml
@@ -4,6 +4,8 @@ metadataTest:
   env:
     - key: JAVA_HOME
       value: /usr/lib/jvm/java-11-amazon-corretto
+    - key: LANG
+      value: C.UTF-8
 
 commandTests:
   - name: "java command is registered using alternatives."


### PR DESCRIPTION
*Issue #, if available:*
see corretto-11-docker [PR #62](https://github.com/corretto/corretto-8-docker/pull/62)
customer issues:  #22 #20 

*Description of changes:*
switch default locale to utf8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
